### PR TITLE
Adeed support to create the cluster-agent-secret yourself

### DIFF
--- a/cluster-agent/README.md
+++ b/cluster-agent/README.md
@@ -16,9 +16,10 @@ imageInfo:
 controllerInfo:
   url: <controller-url>
   account: <controller-account>
-  username: <controller-username>
-  password: <controller-password>
-  accessKey: <controller-accesskey>
+  secret:
+    username: <controller-username>
+    password: <controller-password>
+    accessKey: <controller-accesskey>
 
 agentServiceAccount: appdynamics-cluster-agent
 operatorServiceAccount: appdynamics-operator
@@ -27,6 +28,15 @@ operatorServiceAccount: appdynamics-operator
 ```bash
 helm install cluster-agent appdynamics-charts/cluster-agent -f <values-file>.yaml --namespace appdynamics
 ```
+### Creating your own secret:
+If you want to create the cluster-agent-secret yourself you can set the following option to false:
+```yaml
+controllerInfo:
+  secret:
+    create: false
+```
+You will need to make sure you create the cluster-agent-secret following the same format/specs as the one in this project.
+
 ### Note:
 For more details and config options please visit official documentation
 [https://docs.appdynamics.com/display/PRO45/Deploy+the+Cluster+Agent+with+Helm+Charts](https://docs.appdynamics.com/display/PRO45/Deploy+the+Cluster+Agent+with+Helm+Charts)

--- a/cluster-agent/templates/secret-cluster-agent.yaml
+++ b/cluster-agent/templates/secret-cluster-agent.yaml
@@ -1,5 +1,7 @@
 {{ $mode := .Values.deploymentMode -}}
+{{ $secret := .Values.controllerInfo.secret.create -}}
 {{ if or (eq $mode "MASTER") (eq $mode "NAMESPACED") -}}
+{{ if $secret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,8 +9,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  {{ with .Values.controllerInfo -}}
+  {{ with .Values.controllerInfo.secret -}}
   controller-key: {{ include "sensitiveData" (dict "data" .accessKey "message" "AppDynamics controller access key is required!") }}
   api-user: {{ cat (.username | trim | required "AppDynamics controller username is required!") "@" (.account | trim | required "AppDynamics controller account is required!") ":" (.password | trim | required "Appdynamics controller password is required!") | nospace | b64enc -}}
   {{- end -}}
+{{ end -}}
 {{ end -}}

--- a/cluster-agent/values.yaml
+++ b/cluster-agent/values.yaml
@@ -13,9 +13,13 @@ imageInfo:
 controllerInfo:
   url: null
   account: null
-  username: null
-  password: null
-  accessKey: null
+  
+  # Want to bring your own secret then change create to false and follow docs
+  secret:
+    create: true
+    username: null
+    password: null
+    accessKey: null
   
   # SSL properties
   customSSLCert: null


### PR DESCRIPTION
We require to create the cluster-agent-secret ourselves due to a gitops deployment which otherwise would leave the secret values in plain text inside a git repo.

I've checked the templates work as expected by running a helm install with the dry run option.

Any questions please let me know; otherwise is this something you'd accept?