### PR TITLE
update selectors and targetPort for machine agent service

### DIFF
--- a/machine-agent/templates/daemonset.yaml
+++ b/machine-agent/templates/daemonset.yaml
@@ -4,27 +4,28 @@ kind: DaemonSet
 metadata:
   name: {{ template "machine-agent.fullname" . }}
   labels:
-    app: {{ template "machine-agent.name" . }}
+    app.kubernetes.io/name: {{ template "machine-agent.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     chart: {{ template "machine-agent.chart" . }}
-    release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "machine-agent.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "machine-agent.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "machine-agent.name" . }}
-        release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "machine-agent.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.daemonset.image.repository }}:{{ .Values.daemonset.image.tag }}"
         imagePullPolicy: {{ .Values.daemonset.image.pullPolicy }}
         ports:
-          - containerPort: {{ .Values.daemonset.port }}
+          - name: analytics
+            containerPort: {{ .Values.daemonset.port }}
         env:
         - name: APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY
           valueFrom:

--- a/machine-agent/templates/service.yaml
+++ b/machine-agent/templates/service.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.analytics.port }}
-      targetPort: http
+      targetPort: {{ .Values.analytics.port }}
       protocol: TCP
-      name: http
+      name: analytics
   selector:
-    app.kubernetes.io/name: {{ include "machine-agent.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: {{ include "machine-agent.name" . }}
+    release: {{ .Release.Name }}

--- a/machine-agent/templates/service.yaml
+++ b/machine-agent/templates/service.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.analytics.port }}
-      targetPort: {{ .Values.analytics.port }}
+      targetPort: analytics
       protocol: TCP
       name: analytics
   selector:
-    app: {{ include "machine-agent.name" . }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "machine-agent.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
This is an example of a way to address issue #16 and issue #18 which prevent use of the analytics forwarding capability of the machine agent as currently configured.

It will use the existing variables to put selectors that match up with what is on the daemonset for the machine agent, and it uses the analytics port defined and referenced in values to determine the internal analytics port as well as the external one. A default of 9090 here will work with the current machine agent analytics container (at least until it falls fully out of use).