### PR TITLE
Fix issue with newlines on windows and all nodeOS's

### DIFF
--- a/cluster-agent/templates/infraviz.yaml
+++ b/cluster-agent/templates/infraviz.yaml
@@ -7,14 +7,14 @@ metadata:
 spec:
     controllerUrl: {{ required "AppDynamics controller URL is required!" .Values.controllerInfo.url }}
     account: {{ required "AppDynamics controller account is required!" .Values.controllerInfo.account }}
-    {{ if eq .Values.infraViz.nodeOS "linux" }}
+    {{ if eq .Values.infraViz.nodeOS "linux" -}}
     image: {{ .Values.imageInfo.machineAgentImage }}:{{ .Values.imageInfo.machineAgentTag -}}
-    {{ else if eq .Values.infraViz.nodeOS "windows" }}
-    imageWin: {{ .Values.imageInfo.machineAgentWinImage }}:{{ .Values.imageInfo.machineAgentWinTag -}}
+    {{ else if eq .Values.infraViz.nodeOS "windows" -}}
+    imageWin: {{ .Values.imageInfo.machineAgentWinImage }}:{{ .Values.imageInfo.machineAgentWinTag }}
     globalAccount: {{ required "AppDynamics controller global account is required when using machine-agent win image!" .Values.controllerInfo.globalAccount -}}
-    {{ else if eq .Values.infraViz.nodeOS "all" }}
+    {{ else if eq .Values.infraViz.nodeOS "all" -}}
     image: {{ .Values.imageInfo.machineAgentImage }}:{{ .Values.imageInfo.machineAgentTag }}
-    imageWin: {{ .Values.imageInfo.machineAgentWinImage }}:{{ .Values.imageInfo.machineAgentWinTag -}}
+    imageWin: {{ .Values.imageInfo.machineAgentWinImage }}:{{ .Values.imageInfo.machineAgentWinTag }}
     globalAccount: {{ required "AppDynamics controller global account is required when using machine-agent win image!" .Values.controllerInfo.globalAccount -}}
     {{- end }}
     {{ with .Values.infraViz -}}


### PR DESCRIPTION
Lines 13 and 17 were causing the lines below them to be collapsed onto a single line, which creates invalid YAML when trying to deploy either windows or windows/linux nodes. Removed the trailing whitespace trim on the two imageWin lines and updated the conditional to match the style of the rest of the template. These changes we're tested using helm install dryruns and deploying a test agent to an AKS cluster we have in Azure that has both Linux and Windows nodes.