### PR TITLE
Add Cluster Resources requests/limits for netviz container in the optional netviz deployment

### DIFF
--- a/cluster-agent/templates/infraviz.yaml
+++ b/cluster-agent/templates/infraviz.yaml
@@ -39,7 +39,7 @@ spec:
     netVizImage: {{ .Values.imageInfo.netVizImage }}:{{ .Values.imageInfo.netvizTag }}
     netVizPort: {{ .Values.netViz.netVizPort -}}
     ResourcesNetViz:
-    {{- toYaml .Values.netViz.resources | nindent 6 }}
+    {{- toYaml .Values.netVizPod.resources | nindent 6 }}
     {{- end}}
     nodeSelector:
     {{- toYaml .Values.infravizPod.nodeSelector | nindent 6 }}

--- a/cluster-agent/templates/infraviz.yaml
+++ b/cluster-agent/templates/infraviz.yaml
@@ -38,6 +38,8 @@ spec:
     {{ if .Values.netViz.enabled -}}
     netVizImage: {{ .Values.imageInfo.netVizImage }}:{{ .Values.imageInfo.netvizTag }}
     netVizPort: {{ .Values.netViz.netVizPort -}}
+    ResourcesNetViz:
+    {{- toYaml .Values.netViz.resources | nindent 6 }}
     {{- end}}
     nodeSelector:
     {{- toYaml .Values.infravizPod.nodeSelector | nindent 6 }}

--- a/cluster-agent/values.yaml
+++ b/cluster-agent/values.yaml
@@ -85,13 +85,6 @@ infraViz:
 netViz:
   enabled: false
   netVizPort: 3892
-  resources:
-    limits:
-      cpu: "200m"
-      memory: "300Mi"
-    requests:
-      cpu: "100m"
-      memory: "150Mi"
 
 # Agent pod specific properties
 agentPod:
@@ -131,6 +124,16 @@ infravizPod:
       memory: "800M"
   # overrideVolumeMounts property is valid only after 0.6.10 operator version
   overrideVolumeMounts:
+
+# Netviz pod specific properties
+netVizPod:
+  resources:
+    limits:
+      cpu: "200m"
+      memory: "300Mi"
+    requests:
+      cpu: "100m"
+      memory: "150Mi"
 
 # Subcharts boolean install switches
 install:

--- a/cluster-agent/values.yaml
+++ b/cluster-agent/values.yaml
@@ -85,6 +85,13 @@ infraViz:
 netViz:
   enabled: false
   netVizPort: 3892
+  resources:
+    limits:
+      cpu: "200m"
+      memory: "300Mi"
+    requests:
+      cpu: "100m"
+      memory: "150Mi"
 
 # Agent pod specific properties
 agentPod:


### PR DESCRIPTION
Currently, while the CRD supports it, the Helm Chart is unable to provide resource limits/requests for the NetViz component, this adds that capability.