### PR TITLE
Fixes empty fields generated in agent manifests

### DIFF
--- a/cluster-agent/templates/cluster-agent.yaml
+++ b/cluster-agent/templates/cluster-agent.yaml
@@ -72,22 +72,25 @@ spec:
   # Pod filter properties
   podFilter:
   {{- toYaml .Values.podFilter | nindent 4 }}
-
+  {{ if .Values.agentPod.nodeSelector }}
   # Node selector
   nodeSelector:
   {{- toYaml .Values.agentPod.nodeSelector | nindent 4 }}
-
+  {{- end }}
+  {{ if .Values.agentPod.tolerations }}
   # Tolerations
   tolerations:
   {{- toYaml .Values.agentPod.tolerations | nindent 4 }}
-
+  {{- end }}
+  {{ if .Values.agentPod.labels }}
   labels:
   {{- toYaml .Values.agentPod.labels | nindent 4 }}
-
+  {{- end }}
+  {{ if .Values.agentPod.resources }}
   # Resources
   resources:
   {{- toYaml .Values.agentPod.resources | nindent 4 }}
-
+  {{- end }}
   {{ with .Values.instrumentationConfig -}}
   {{ if .enabled -}}
   # Instrumentation config


### PR DESCRIPTION
The way the templating for the cluster-agent is defined now, will always create a tolerations, labels and nodeSelector fields regardless if these fields have values defined for them or not. These fields on the final manifest will just be empty.
`
labels: {}
nodeSelector: {}
tolerations: []
`

While this does not cause issues when the agent is deployed directly via Helm (e.g. via helm install) it does cause issues when deployed via ArgoCD. Argo will try and deploy the manifest (generated using helm template) with the empty fields included, but the final manifest on the cluster will omit this fields. As a result, Argo will identify a diff between the desired and applied manifest and try to apply it again. This results in a sync loop which drains resources from the argoCD deployment.

This pull request adds some if statements on the cluster-agent template, and omits these fields if they are undefined in the provided values file.