### PR TITLE
Feat/existing secret

### DIFF
--- a/cluster-agent/Chart.yaml
+++ b/cluster-agent/Chart.yaml
@@ -9,6 +9,11 @@ version: 1.3.0
 
 appVersion: 22.4.0
 
+dependencies:
+  - name: metrics-server
+    repository: https://kubernetes-sigs.github.io/metrics-server/
+    version: 3.7.0 
+    condition: install.metrics-server
 
 maintainers:
   - name: AppDynamics

--- a/cluster-agent/values.yaml
+++ b/cluster-agent/values.yaml
@@ -21,11 +21,11 @@ imageInfo:
 # AppDynamics controller info (VALUES TO BE PROVIDED BY THE USER)
 controllerInfo:
   existingSecret: false
-  url: test
-  account: test
+  url: null
+  account: null
   username: null
   password: null
-  accessKey: test
+  accessKey: null
   globalAccount: null            # To be provided when using machineAgent Window Image
 
   # SSL properties


### PR DESCRIPTION
## What
This pull request adds an extra field in the values.yaml  `controllerInfo.existingSecret` which can be set as true or false. It then wraps around the creation of the `cluster-agent-secret` secret. If set as true, then the secret template will not be processed and a secret will not be created.

## Why
The current solution for using an existing secret does not work well with ArgoCD, as the lookup feature is not supported by Argo.
 
## How
Bypassing the lookup using the new field, solves the issue without affecting existing functionality.