### PR TITLE
Appdynamics machine agent remore psp for k8s 1.25

### DIFF
--- a/machine-agent/Chart.yaml
+++ b/machine-agent/Chart.yaml
@@ -4,7 +4,7 @@ description: AppDynamics Machine Agent for infrastructure visibility
 home: https://www.appdynamics.com/
 icon: https://raw.githubusercontent.com/CiscoDevNet/appdynamics-charts/master/logo.png
 name: machine-agent
-version: 0.2.8
+version: 0.2.9
 maintainers:
   - name: sashaPM
     email: sasha.jeltuhin@appdynamics.com

--- a/machine-agent/templates/netviz-rbac.yaml
+++ b/machine-agent/templates/netviz-rbac.yaml
@@ -31,7 +31,8 @@ spec:
     rule: 'RunAsAny'
   fsGroup:
     rule: 'RunAsAny'
----
+{{- end -}}
+{{- if and (eq .Values.agent.netviz true) ( eq .Values.openshift.scc false) }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/machine-agent/templates/netviz-rbac.yaml
+++ b/machine-agent/templates/netviz-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.agent.netviz true) ( eq .Values.openshift.scc false) }}
+{{- if and (eq .Values.agent.netviz true) ( eq .Values.openshift.scc false) ( eq .Values.agent.netvizPsp true ) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/machine-agent/values.yaml
+++ b/machine-agent/values.yaml
@@ -57,6 +57,7 @@ agent:
   uniqueHostId: ""
   enableContainerAsHostID: false
   netviz: false
+  netvizPsp: false
   netvizPort: 3892
   netvizImage:
     repository: docker.io/appdynamics/machine-agent-netviz


### PR DESCRIPTION
   PodSecurityPolicy was deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25. Allow option PSP to be disables for migration to K8S 1.25.